### PR TITLE
Fixed taskfile typo for serve command

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,7 +13,7 @@ tasks:
 
       Runs the backend python application
       and serve the frontend react client.
-    cmd:
+    cmds:
       - task: serve:backend
       - task: serve:frontend
 
@@ -50,7 +50,7 @@ tasks:
       runs a new scraping session to get new
       questions.
     dir: scraper
-    deps: [refresh]
+    deps: [ refresh ]
     cmds:
       - scrapy crawl games
       - task: scrape:copy

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -64,7 +64,7 @@ tasks:
     summary: |
       Removes old data from scraping and
       clears all caches.
-    cmd:
+    cmds:
       - rm data/dump.json
       - rm backend/data/dump.json
       - rm -rf scraper/scraper/__pycache__/


### PR DESCRIPTION
# Description

the serve command accidentally had the `cmd` directive not `cmds` which wouldn't allow the subcommands to run.﻿
